### PR TITLE
Управление уникальными номерами счетов

### DIFF
--- a/src/main/java/faang/school/accountservice/model/AccountNumbersSequence.java
+++ b/src/main/java/faang/school/accountservice/model/AccountNumbersSequence.java
@@ -1,0 +1,40 @@
+package faang.school.accountservice.model;
+
+import faang.school.accountservice.enums.AccountType;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "account_numbers_sequence")
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class AccountNumbersSequence {
+
+    @Id
+    @Enumerated(EnumType.STRING)
+    @Column(name = "account_type")
+    private AccountType accountType;
+
+    @Column(name = "current_value")
+    private Long currentValue;
+
+    @Version
+    @Column(name = "version")
+    private Long version;
+
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
+
+    @PrePersist
+    @PreUpdate
+    private void preUpdate() {
+        updatedAt = LocalDateTime.now();
+    }
+}

--- a/src/main/java/faang/school/accountservice/model/FreeAccountNumber.java
+++ b/src/main/java/faang/school/accountservice/model/FreeAccountNumber.java
@@ -1,0 +1,39 @@
+package faang.school.accountservice.model;
+
+import faang.school.accountservice.enums.AccountType;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "free_account_numbers")
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@IdClass(FreeAccountNumberId.class)
+public class FreeAccountNumber {
+
+    @Id
+    @Enumerated(EnumType.STRING)
+    @Column(name = "account_type")
+    private AccountType accountType;
+
+    @Id
+    @Column(name = "account_number")
+    private String accountNumber;
+
+    @Column(name = "created_at")
+    private LocalDateTime createdAt;
+
+    @PrePersist
+    private void prePersist() {
+        if (createdAt == null) {
+            createdAt = LocalDateTime.now();
+        }
+    }
+}

--- a/src/main/java/faang/school/accountservice/model/FreeAccountNumberId.java
+++ b/src/main/java/faang/school/accountservice/model/FreeAccountNumberId.java
@@ -1,0 +1,30 @@
+package faang.school.accountservice.model;
+
+import faang.school.accountservice.enums.AccountType;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.io.Serializable;
+import java.util.Objects;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class FreeAccountNumberId implements Serializable {
+    private AccountType accountType;
+    private String accountNumber;
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        FreeAccountNumberId that = (FreeAccountNumberId) o;
+        return accountType == that.accountType && Objects.equals(accountNumber, that.accountNumber);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(accountType, accountNumber);
+    }
+}

--- a/src/main/java/faang/school/accountservice/repository/AccountNumbersSequenceRepository.java
+++ b/src/main/java/faang/school/accountservice/repository/AccountNumbersSequenceRepository.java
@@ -1,0 +1,29 @@
+package faang.school.accountservice.repository;
+
+import faang.school.accountservice.enums.AccountType;
+import faang.school.accountservice.model.AccountNumbersSequence;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+
+@Repository
+public interface AccountNumbersSequenceRepository extends JpaRepository<AccountNumbersSequence, AccountType> {
+
+    @Modifying
+    @Transactional
+    @Query("UPDATE AccountNumbersSequence a SET a.currentValue = a.currentValue + 1 " +
+            "WHERE a.accountType = :accountType AND a.currentValue = :expectedValue")
+    int incrementSequence(@Param("accountType") AccountType accountType,
+                          @Param("expectedValue") Long expectedValue);
+
+    @Query("SELECT a FROM AccountNumbersSequence a WHERE a.accountType = :accountType")
+    Optional<AccountNumbersSequence> findByAccountType(@Param("accountType") AccountType accountType);
+
+    @Query("SELECT a.currentValue FROM AccountNumbersSequence a WHERE a.accountType = :accountType")
+    Optional<Long> getCurrentValue(@Param("accountType") AccountType accountType);
+}

--- a/src/main/java/faang/school/accountservice/repository/FreeAccountNumbersRepository.java
+++ b/src/main/java/faang/school/accountservice/repository/FreeAccountNumbersRepository.java
@@ -1,0 +1,42 @@
+package faang.school.accountservice.repository;
+
+import faang.school.accountservice.enums.AccountType;
+import faang.school.accountservice.model.FreeAccountNumber;
+import faang.school.accountservice.model.FreeAccountNumberId;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+
+@Repository
+public interface FreeAccountNumbersRepository extends JpaRepository<FreeAccountNumber, FreeAccountNumberId> {
+
+    @Modifying
+    @Transactional
+    @Query(value = """
+        DELETE FROM free_account_numbers 
+        WHERE account_type = :accountType 
+        AND account_number = (
+            SELECT account_number 
+            FROM free_account_numbers 
+            WHERE account_type = :accountType 
+            ORDER BY account_number 
+            LIMIT 1
+        ) 
+        RETURNING account_number
+        """, nativeQuery = true)
+    Optional<String> findFirstAndDeleteByAccountType(@Param("accountType") String accountType);
+
+    @Query("SELECT COUNT(f) FROM FreeAccountNumber f WHERE f.accountType = :accountType")
+    long countByAccountType(@Param("accountType") AccountType accountType);
+
+    @Modifying
+    @Transactional
+    @Query("DELETE FROM FreeAccountNumber f WHERE f.accountType = :accountType AND f.accountNumber = :accountNumber")
+    int deleteByAccountTypeAndAccountNumber(@Param("accountType") AccountType accountType,
+                                            @Param("accountNumber") String accountNumber);
+}

--- a/src/main/java/faang/school/accountservice/repository/FreeAccountNumbersRepository.java
+++ b/src/main/java/faang/school/accountservice/repository/FreeAccountNumbersRepository.java
@@ -33,10 +33,4 @@ public interface FreeAccountNumbersRepository extends JpaRepository<FreeAccountN
 
     @Query("SELECT COUNT(f) FROM FreeAccountNumber f WHERE f.accountType = :accountType")
     long countByAccountType(@Param("accountType") AccountType accountType);
-
-    @Modifying
-    @Transactional
-    @Query("DELETE FROM FreeAccountNumber f WHERE f.accountType = :accountType AND f.accountNumber = :accountNumber")
-    int deleteByAccountTypeAndAccountNumber(@Param("accountType") AccountType accountType,
-                                            @Param("accountNumber") String accountNumber);
 }

--- a/src/main/java/faang/school/accountservice/service/account/AccountServiceImpl.java
+++ b/src/main/java/faang/school/accountservice/service/account/AccountServiceImpl.java
@@ -1,42 +1,72 @@
 package faang.school.accountservice.service.account;
 
 import faang.school.accountservice.dto.AccountDto;
+import faang.school.accountservice.enums.AccountStatus;
+import faang.school.accountservice.enums.AccountType;
 import faang.school.accountservice.exceptions.DataValidationException;
 import faang.school.accountservice.mapper.AccountMapper;
 import faang.school.accountservice.model.Account;
 import faang.school.accountservice.repository.AccountRepository;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class AccountServiceImpl implements AccountService {
 
     private final AccountRepository accountRepository;
     private final AccountMapper accountMapper;
+    private final FreeAccountNumbersService freeAccountNumbersService;
 
     @Transactional
     @Override
     public AccountDto create(AccountDto accountDto) {
+        log.info("Creating account for user: {}, project: {}", accountDto.getUserId(), accountDto.getProjectId());
+
+        AccountType accountType = determineAccountType(accountDto);
         Account account = accountMapper.toEntity(accountDto);
+        account.setType(accountType);
+        account.setStatus(AccountStatus.ACTIVE);
+
+        freeAccountNumbersService.executeWithFreeAccountNumber(
+                accountType,
+                accountNumber -> {
+                    account.setAccountNumber(accountNumber);
+                    log.debug("Assigned account number: {} to account", accountNumber);
+                }
+        );
+
         Account savedAccount = accountRepository.save(account);
+        log.info("Successfully created account with ID: {} and number: {}",
+                savedAccount.getId(), savedAccount.getAccountNumber());
+
         return accountMapper.toDto(savedAccount);
     }
 
     @Transactional
     @Override
     public AccountDto update(Long id, AccountDto accountDto) {
+        log.info("Updating account with ID: {}", id);
+
         Account account = accountRepository.findById(id)
                 .orElseThrow(() -> new DataValidationException("Account not found with id: " + id));
+
         accountMapper.update(account, accountDto);
+
         Account updatedAccount = accountRepository.save(account);
+        log.info("Successfully updated account with ID: {}", id);
+
         return accountMapper.toDto(updatedAccount);
     }
 
     @Transactional(readOnly = true)
     @Override
     public AccountDto getAccount(Long id) {
+        log.debug("Retrieving account with ID: {}", id);
+
         return accountRepository.findById(id)
                 .map(accountMapper::toDto)
                 .orElseThrow(() -> new DataValidationException("Account not found with id: " + id));
@@ -45,9 +75,39 @@ public class AccountServiceImpl implements AccountService {
     @Transactional
     @Override
     public void delete(Long id) {
+        log.info("Deleting account with ID: {}", id);
+
         if (!accountRepository.existsById(id)) {
             throw new DataValidationException("Account not found with id: " + id);
         }
+
+        Account account = accountRepository.findById(id)
+                .orElseThrow(() -> new DataValidationException("Account not found with id: " + id));
+
         accountRepository.deleteById(id);
+
+        try {
+            freeAccountNumbersService.saveFreeAccountNumber(account.getType(), account.getAccountNumber());
+            log.info("Returned account number {} to free pool for type {}",
+                    account.getAccountNumber(), account.getType());
+        } catch (Exception e) {
+            log.warn("Failed to return account number {} to free pool: {}",
+                    account.getAccountNumber(), e.getMessage());
+        }
+
+        log.info("Successfully deleted account with ID: {}", id);
+    }
+
+    private AccountType determineAccountType(AccountDto accountDto) {
+
+        if (accountDto.getUserId() != null && accountDto.getProjectId() != null) {
+            return AccountType.PERSONAL_PHYSICAL;
+        } else if (accountDto.getUserId() != null) {
+            return AccountType.PERSONAL_PHYSICAL;
+        } else if (accountDto.getProjectId() != null) {
+            return AccountType.CORPORATE;
+        } else {
+            throw new DataValidationException("Cannot determine account type: both userId and projectId are null");
+        }
     }
 }

--- a/src/main/java/faang/school/accountservice/service/account/FreeAccountNumbersService.java
+++ b/src/main/java/faang/school/accountservice/service/account/FreeAccountNumbersService.java
@@ -1,0 +1,181 @@
+package faang.school.accountservice.service.account;
+
+import faang.school.accountservice.enums.AccountType;
+import faang.school.accountservice.exceptions.DataValidationException;
+import faang.school.accountservice.model.AccountNumbersSequence;
+import faang.school.accountservice.model.FreeAccountNumber;
+import faang.school.accountservice.repository.AccountNumbersSequenceRepository;
+import faang.school.accountservice.repository.FreeAccountNumbersRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Consumer;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class FreeAccountNumbersService {
+
+    private final FreeAccountNumbersRepository freeAccountNumbersRepository;
+    private final AccountNumbersSequenceRepository sequenceRepository;
+
+    private static final Map<AccountType, String> ACCOUNT_TYPE_PREFIXES = Map.of(
+            AccountType.PERSONAL_PHYSICAL, "4200",
+            AccountType.PERSONAL_LEGAL, "4201",
+            AccountType.CURRENCY, "4202",
+            AccountType.SAVINGS, "5236",
+            AccountType.CORPORATE, "4203"
+    );
+
+    private static final int ACCOUNT_NUMBER_LENGTH = 16;
+    private static final int MAX_RETRY_ATTEMPTS = 10;
+
+    @Transactional
+    public void generateAndSaveFreeAccountNumbers(AccountType accountType, int count) {
+        if (count <= 0) {
+            throw new DataValidationException("Count must be positive");
+        }
+
+        log.info("Generating {} free account numbers for type: {}", count, accountType);
+
+        for (int i = 0; i < count; i++) {
+            String accountNumber = generateNewAccountNumber(accountType);
+            if (accountNumber != null) {
+                saveFreeAccountNumber(accountType, accountNumber);
+            } else {
+                log.warn("Failed to generate account number {} of {}", i + 1, count);
+            }
+        }
+    }
+
+    @Transactional
+    public void saveFreeAccountNumber(AccountType accountType, String accountNumber) {
+        validateAccountNumber(accountNumber);
+
+        FreeAccountNumber freeAccountNumber = FreeAccountNumber.builder()
+                .accountType(accountType)
+                .accountNumber(accountNumber)
+                .build();
+
+        freeAccountNumbersRepository.save(freeAccountNumber);
+        log.debug("Saved free account number: {} for type: {}", accountNumber, accountType);
+    }
+
+    @Transactional
+    public void executeWithFreeAccountNumber(AccountType accountType, Consumer<String> action) {
+        String accountNumber = getAndRemoveFreeAccountNumber(accountType);
+        if (accountNumber == null) {
+            accountNumber = generateNewAccountNumber(accountType);
+            if (accountNumber == null) {
+                throw new DataValidationException("Unable to generate account number for type: " + accountType);
+            }
+        }
+
+        try {
+            action.accept(accountNumber);
+            log.info("Successfully executed action with account number: {}", accountNumber);
+        } catch (Exception e) {
+            log.error("Failed to execute action with account number: {}", accountNumber, e);
+            saveFreeAccountNumber(accountType, accountNumber);
+            throw e;
+        }
+    }
+
+    @Transactional
+    public String getAndRemoveFreeAccountNumber(AccountType accountType) {
+        Optional<String> accountNumber = freeAccountNumbersRepository
+                .findFirstAndDeleteByAccountType(accountType.name());
+
+        if (accountNumber.isPresent()) {
+            log.debug("Retrieved and removed free account number: {} for type: {}",
+                    accountNumber.get(), accountType);
+            return accountNumber.get();
+        }
+
+        log.debug("No free account numbers available for type: {}", accountType);
+        return null;
+    }
+
+    @Transactional
+    public void initializeSequence(AccountType accountType) {
+        if (sequenceRepository.findByAccountType(accountType).isEmpty()) {
+            AccountNumbersSequence sequence = AccountNumbersSequence.builder()
+                    .accountType(accountType)
+                    .currentValue(0L)
+                    .version(0L)
+                    .build();
+
+            sequenceRepository.save(sequence);
+            log.info("Initialized sequence for account type: {}", accountType);
+        }
+    }
+
+    public long getFreeAccountNumbersCount(AccountType accountType) {
+        return freeAccountNumbersRepository.countByAccountType(accountType);
+    }
+
+    private String generateNewAccountNumber(AccountType accountType) {
+        String prefix = ACCOUNT_TYPE_PREFIXES.get(accountType);
+        if (prefix == null) {
+            throw new DataValidationException("No prefix configured for account type: " + accountType);
+        }
+
+        for (int attempts = 0; attempts < MAX_RETRY_ATTEMPTS; attempts++) {
+            Optional<Long> currentValueOpt = sequenceRepository.getCurrentValue(accountType);
+            Long currentValue;
+
+            if (currentValueOpt.isEmpty()) {
+                initializeSequence(accountType);
+                currentValue = 0L;
+            } else {
+                currentValue = currentValueOpt.get();
+            }
+
+            long nextValue = currentValue + 1;
+            int updatedRows = sequenceRepository.incrementSequence(accountType, currentValue);
+
+            if (updatedRows > 0) {
+                return formatAccountNumber(prefix, nextValue);
+            }
+
+            try {
+                Thread.sleep(10 + attempts * 5);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw new DataValidationException("Interrupted while generating account number");
+            }
+        }
+
+        log.error("Failed to generate account number after {} attempts for type: {}", MAX_RETRY_ATTEMPTS, accountType);
+        return null;
+    }
+
+    private String formatAccountNumber(String prefix, long sequenceValue) {
+        String numberPart = String.valueOf(sequenceValue);
+        int paddingLength = ACCOUNT_NUMBER_LENGTH - prefix.length();
+
+        if (numberPart.length() > paddingLength) {
+            throw new DataValidationException("Sequence value too large for account number format");
+        }
+
+        return prefix + String.format("%0" + paddingLength + "d", sequenceValue);
+    }
+
+    private void validateAccountNumber(String accountNumber) {
+        if (accountNumber == null || accountNumber.trim().isEmpty()) {
+            throw new DataValidationException("Account number cannot be null or empty");
+        }
+
+        if (accountNumber.length() < 12 || accountNumber.length() > 20) {
+            throw new DataValidationException("Account number length must be between 12 and 20 characters");
+        }
+
+        if (!accountNumber.matches("\\d+")) {
+            throw new DataValidationException("Account number must contain only digits");
+        }
+    }
+}

--- a/src/main/resources/db/changelog/changeset/V004__create_free_account_numbers_table.sql
+++ b/src/main/resources/db/changelog/changeset/V004__create_free_account_numbers_table.sql
@@ -1,0 +1,14 @@
+CREATE TABLE free_account_numbers (
+                                      account_type VARCHAR(50) NOT NULL,
+                                      account_number VARCHAR(20) NOT NULL CHECK (account_number ~ '^\d{12,20}$'),
+    created_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP NOT NULL,
+
+    CONSTRAINT pk_free_account_numbers PRIMARY KEY (account_type, account_number)
+);
+
+CREATE INDEX idx_free_account_numbers_type ON free_account_numbers(account_type);
+
+COMMENT ON TABLE free_account_numbers IS 'Таблица для хранения свободных номеров счетов';
+COMMENT ON COLUMN free_account_numbers.account_type IS 'Тип счета';
+COMMENT ON COLUMN free_account_numbers.account_number IS 'Номер счета';
+COMMENT ON COLUMN free_account_numbers.created_at IS 'Дата создания записи';

--- a/src/main/resources/db/changelog/changeset/V005__create_account_numbers_sequence_table.sql
+++ b/src/main/resources/db/changelog/changeset/V005__create_account_numbers_sequence_table.sql
@@ -1,0 +1,14 @@
+CREATE TABLE account_numbers_sequence (
+                                          account_type VARCHAR(50) NOT NULL,
+                                          current_value BIGINT NOT NULL DEFAULT 0,
+                                          version BIGINT NOT NULL DEFAULT 0,
+                                          updated_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP NOT NULL,
+
+                                          CONSTRAINT pk_account_numbers_sequence PRIMARY KEY (account_type)
+);
+
+COMMENT ON TABLE account_numbers_sequence IS 'Таблица для хранения счетчиков номеров счетов';
+COMMENT ON COLUMN account_numbers_sequence.account_type IS 'Тип счета';
+COMMENT ON COLUMN account_numbers_sequence.current_value IS 'Текущее значение счетчика';
+COMMENT ON COLUMN account_numbers_sequence.version IS 'Версия для optimistic locking';
+COMMENT ON COLUMN account_numbers_sequence.updated_at IS 'Дата последнего обновления';

--- a/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -5,3 +5,7 @@ databaseChangeLog:
       file: db/changelog/changeset/V002__account-service_account.sql
   - include:
       file: db/changelog/changeset/V003__account-service_account.sql
+  - include:
+      file: db/changelog/changeset/V004__create_free_account_numbers_table.sql
+  - include:
+      file: db/changelog/changeset/V005__create_account_numbers_sequence_table.sql


### PR DESCRIPTION
Условия задачи
Номер платежного счета - это уникальный идентификатор, который используется для идентификации конкретного счета в системе платежей или банковской системе

В account_service настроить хранение и управление уникальнми номерами счетов. Номера должны генерироваться заранее, чтобы при создании аккаунта пользователя новому аккаунту присваивался заранее сгенерированный номер

Это позволить ускорить создание нового счёта (не придётся с нуля генерировать новый номер счета и ещё и позаботиться о консистентности и уникальности). При это благодаря этому можно будет переиспользовать код, который генерирует новый номер счета для разных типов счетов

Когда создается какой-либо новый счет, номер из таблицы для хранения свободных номеров платежных счетов может быть выбран и и тут же удален из таблицы, чтобы избежать повторного использования

Таблица для хранения свободных номеров должна содержать тип платежного счета и свободный номер платежного счета данного типа

В этой задаче нам нужно создать необходимые таблицы и предоставить удобные функции для того, что бы разные продукты (разные типы счетов) могли быстро и легко интегрировать получение и генерацию уникальных номеров счетов

Вот некоторые ограничения, которые мы имеем для создания номеров счетов:

Номер счета должен быть уникальным для каждого типа счета в системе. Два счета одного типа не могут иметь один и тот же номер счета

Длина может быть фиксированной или переменной. Обычно номера счетов имеют от 12 до 20 символов

Номер платежного аккаунта может содержать только цифры (проверять на уровне приложения)

Тех. детали
Написать миграцию для создания таблицы free_account_numbers, которая будет хранить все свободные номера счетов для конкретного типа счета. Необходимо составить оптимальный первичный ключ для таблица, а также выбрать подходящие типы для столбцов

Написать FreeAccountNumbersRepository. В нём должен быть метод для создания нового свободного номера счета. А так же метод, который транзакционно найдет первый свободный номер счета, удалит его и вернёт результат. Можно использовать конструкцию DELETE RETURNING в PostgreSQL, или написать в сервисе транзакционный метод, который вызовет 2 метода, один получения, другой удаления.

Написать миграцию для создания таблицы account_numbers_sequence. Она будет содержать текущий счётчик (число) для каждого типа счета. Идея такая, что при генерации новых номеров счетов в free_account_numbers мы транзакционно инкрементируем данный счетчик и добавляем сгенерированный номер счета в таблицу free_account_numbers. Нужен единственный счетчик для каждого типа счета. Например для дебетовых счетов будет номер счета 4200 0000 0000 0001, где 4200 это первые 4 цифры, зарезервированные для конкретного типа счета (например 4200 для дебетовых, 5236 для накопительных), а остальные 8-12 цифр будут составлять одно число - значение текущего счета. Т.е. счетчик 1 для дебетового счета превратится в 4200 0000 0000 0001, а счетчик 12345 превратится в 4200 0000 0001 2345. Конкатенация первых 4 цифр типа счета и конкретного номера счета должно происходить на уровне приложения.

Написать AccountNumbersSequenceRepository, (можно использовать JpaRepository, или NamedParameterJdbcTemplate). Написать там методы для создания счетчика для конкретного типа счета (счетчик начинается с нуля). А так же метод, который инкрементирует счетчик, в случае если счетчик равен конкретному значению. Метод должен возвращать boolean, (удалось ли инкрементировать счетчик или нет). Это будет реализацией Optimistic Lock. Пример реализации - [Optimistic Locking in JPA | Baeldung](https://www.baeldung.com/jpa-optimistic-locking)  Таким образом мы дадим возможность только одной транзакции инкрементировать и забрать новый номер счета

Написать FreeAccountNumbersService (заинджектить туда два наших репозитория). В этом сервисе нужно предоставить максимально удобные методы для записи новых номеров счетов. А так же нужен специальный метод, который принимает лямбду. Он транзакционно получит и тут же удалит новый свободный номер счета (если такой есть), а потом в той же транзакции выполнит метод, переданный в лямбде. В лямбду например можно передать метод, который создаст запись в таблице account с новым полученным номером счета. Нужно предусмотреть случай, когда свободного номера счета не оказалось, тогда нужно самостоятельно инкрементировать счетчик и получить новый номер счета.

Покрыть сервиный слой тестами. Желательно использовать TestContainers и не мокать слой репозиториев.

----------------------------------

- Добавлена модель AccountNumbersSequence с optimistic locking для потокобезопасного управления счетчиками
- Добавлена модель FreeAccountNumber с композитным ключом для хранения переиспользуемых номеров счетов
- Создан сервис FreeAccountNumbersService с пулом номеров счетов и их переработкой
- Интегрировано автоматическое присвоение номеров счетов в AccountServiceImpl
- Добавлены миграции БД для таблиц account_numbers_sequence и free_account_numbers
- Реализован возврат номеров счетов в пул при удалении счета